### PR TITLE
fix # 6

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ const exportFn = (options: VitePluginCompression = {}): Plugin => {
     enforce: 'post',
     configResolved(resolvedConfig) {
       config = resolvedConfig;
-      outputPath = path.join(config.root, config.build.outDir);
+      outputPath = path.isAbsolute(config.build.outDir)?config.build.outDir:path.join(config.root, config.build.outDir);
       debug('resolvedConfig:', resolvedConfig);
     },
     async writeBundle() {


### PR DESCRIPTION
修复config.build.outDir为绝对路径时, outputPath解析异常
![image](https://user-images.githubusercontent.com/26101366/126138633-f4db202a-441f-4746-bda4-fa083a83a2a5.png)
 