### PR TITLE
Add success callback after completed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ const exportFn = (options: VitePluginCompression = {}): Plugin => {
     threshold = 1025,
     compressionOptions = {},
     deleteOriginFile = false,
+    success = () => {}
   } = options;
 
   if (disable) {
@@ -93,6 +94,7 @@ const exportFn = (options: VitePluginCompression = {}): Plugin => {
       Promise.all(handles).then(() => {
         if (verbose) {
           handleOutputLogger(config, compressMap, algorithm);
+          success()
         }
       });
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,4 +46,9 @@ export interface VitePluginCompression {
    * @default: false
    */
   deleteOriginFile?: boolean;
+
+  /**
+   * success callback after completed
+   */
+  success?: Function;
 }


### PR DESCRIPTION
Callback can be performed after the operation is completed, which is convenient for the work of other serial plug-ins