### PR TITLE
fix: showing absolute path in verbose mode

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -218,9 +218,8 @@ function handleOutputLogger(
   compressMap.forEach((value, name) => {
     const { size, oldSize, cname } = value
 
-    const rName = normalizePath(cname).replace(
-      normalizePath(`${config.build.outDir}/`),
-      '',
+    const rName = normalizePath(
+      path.relative(path.resolve(config.root, config.build.outDir), cname),
     )
 
     const sizeStr = `${oldSize.toFixed(2)}kb / ${algorithm}: ${size.toFixed(


### PR DESCRIPTION

Before:

```
dist//Users/wangxinhe/Documents/GitHub/repository/index.html.br  1.59kb / brotliCompress: 0.51kb
```

![截屏2022-06-12 23.36.35.png](https://user-images.githubusercontent.com/29367025/173241066-8ebe153c-e33f-49f2-85ea-c5a123e63e1b.png)

After:

```
dist/index.html.br  1.59kb / brotliCompress: 0.51kb
```

![截屏2022-06-12 23.38.43.png](https://user-images.githubusercontent.com/29367025/173241164-a58e68c7-eb21-4e28-b803-88ddb9fee328.png)

