### PR TITLE
Fix output file path

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -218,10 +218,7 @@ function handleOutputLogger(
   compressMap.forEach((value, name) => {
     const { size, oldSize, cname } = value
 
-    const rName = normalizePath(cname).replace(
-      normalizePath(`${config.build.outDir}/`),
-      '',
-    )
+    const rName = path.relative(config.build.outDir, cname);
 
     const sizeStr = `${oldSize.toFixed(2)}kb / ${algorithm}: ${size.toFixed(
       2,


### PR DESCRIPTION
Before:

```
✨ [vite-plugin-compression]:algorithm=gzip - compressed file successfully: 
dist//home/okineadev/okineadev-website/assets/index-D5sQ9fjY.js.gz    1.92kb / gzip: 0.98kb
dist//home/okineadev/okineadev-website/assets/index-BdTX-HY2.css.gz   22.35kb / gzip: 6.13kb
dist//home/okineadev/okineadev-website/index.html.gz  
```

After:

```
✨ [vite-plugin-compression]:algorithm=gzip - compressed file successfully: 
dist/assets/index-BdTX-HY2.css.gz   22.35kb / gzip: 6.13kb
dist/assets/index-D5sQ9fjY.js.gz    1.92kb / gzip: 0.98kb
dist/index.html.gz                  14.87kb / gzip: 4.87kb
```